### PR TITLE
FIX: Rename lineHeight

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Styles (0.16.13)
-  - Styles/Tests (0.16.13)
+  - Styles (0.18.13)
+  - Styles/Tests (0.18.13)
 
 DEPENDENCIES:
   - Styles (from `../`)
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Styles: 7986c4b462f2b2bd2d6829bb1dec8de393f136f4
+  Styles: 06c404130b40d3e02cad8d7bb0c91444fafebce2
 
 PODFILE CHECKSUM: f5341d1bc44d76e5ca1e0d50940004053970d8dc
 

--- a/Example/Pods/Local Podspecs/Styles.podspec.json
+++ b/Example/Pods/Local Podspecs/Styles.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Styles",
-  "version": "0.16.13",
+  "version": "0.18.13",
   "summary": "UI Elements rapid styling",
   "description": "UIElements styling made easy, declarative and rapid.",
   "homepage": "https://github.com/inloop/Styles",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/inloop/Styles.git",
-    "tag": "0.16.13"
+    "tag": "0.18.13"
   },
   "platforms": {
     "ios": "10.0"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Styles (0.16.13)
-  - Styles/Tests (0.16.13)
+  - Styles (0.18.13)
+  - Styles/Tests (0.18.13)
 
 DEPENDENCIES:
   - Styles (from `../`)
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Styles: 7986c4b462f2b2bd2d6829bb1dec8de393f136f4
+  Styles: 06c404130b40d3e02cad8d7bb0c91444fafebce2
 
 PODFILE CHECKSUM: f5341d1bc44d76e5ca1e0d50940004053970d8dc
 

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -66,7 +66,7 @@
 
 /* Begin PBXFileReference section */
 		07683D672B6879FD85FB6047D1F3B9E9 /* Array+Styles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Array+Styles.swift"; sourceTree = "<group>"; };
-		0981D5901CED03DD1D0CA52CF6111F1A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		0981D5901CED03DD1D0CA52CF6111F1A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
 		1395CE5809BA9EA11FDB1CED4C716582 /* UIImage+Colorize.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIImage+Colorize.swift"; sourceTree = "<group>"; };
 		145B1927D42A377E7E70DF4519008FA7 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1F600D5C8375D6976D8D33CBA59579AE /* Pods-Styles_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Styles_Example-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -75,13 +75,13 @@
 		32F51507323EA8324438A81D7A06608A /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		38998D66DDF5A96AF1E14C20D2426D70 /* Pods-Styles_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Styles_Example-frameworks.sh"; sourceTree = "<group>"; };
 		4030761350C82C916FA61309A8F809D1 /* ViewStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViewStyle.swift; path = Styles/Classes/ViewStyle.swift; sourceTree = "<group>"; };
-		40EA5E9F944CF3C551B4A661A6834D27 /* Pods_Styles_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Styles_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		40EA5E9F944CF3C551B4A661A6834D27 /* Pods_Styles_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Styles_Example.framework; path = "Pods-Styles_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		40F23516D747302C15FBB637BF569EE5 /* Regex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Regex.swift; sourceTree = "<group>"; };
 		45C8BF1E9B23A10609E7EB62060C872B /* UIImage+Attachment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIImage+Attachment.swift"; sourceTree = "<group>"; };
 		4F83696DA73AB40B0403B8D40F27E5E1 /* Styles.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Styles.xcconfig; sourceTree = "<group>"; };
 		521844D5DC3EBDD8FF2C666C15604BB3 /* Styles-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Styles-prefix.pch"; sourceTree = "<group>"; };
 		60096B5309FCD3AC32100C87013BFACB /* NSAttributedString+Mutable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Mutable.swift"; sourceTree = "<group>"; };
-		666A0460CCB2754AC7E7B07E6425D93C /* Styles.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Styles.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		666A0460CCB2754AC7E7B07E6425D93C /* Styles.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Styles.framework; path = Styles.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6BADD400D9DBE286A485EF9C357DC617 /* UILabel+Styles.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UILabel+Styles.m"; sourceTree = "<group>"; };
 		6CECE929214C7D2760FC259EC473D437 /* TextStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TextStyle.swift; path = Styles/Classes/TextStyle.swift; sourceTree = "<group>"; };
 		772661D4E69DB9060E7ABEC7EBC2C5DE /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -94,10 +94,10 @@
 		838FB6B409692D1288F5B23AB4F8A9B5 /* Swizzle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Swizzle.h; sourceTree = "<group>"; };
 		87B27F17303D3A1727ADC458CE871CC3 /* Styles-Unit-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Styles-Unit-Tests-resources.sh"; sourceTree = "<group>"; };
 		8ACC060C63F823790970C8B61EF27186 /* TextEffect.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TextEffect.swift; path = Styles/Classes/TextEffect.swift; sourceTree = "<group>"; };
-		8B6ADE86223534102FFF167BD456C70C /* Styles.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; path = Styles.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		8B6ADE86223534102FFF167BD456C70C /* Styles.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = Styles.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		8DB5DB48ECAC95A9728A95515031EE54 /* ViewStyleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViewStyleTests.swift; path = Styles/Tests/ViewStyleTests.swift; sourceTree = "<group>"; };
 		8FAFF03CFF3237AF5C6A9B35F4522655 /* UITextView+Styles.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UITextView+Styles.m"; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		982839AD4C2C3FFE273B1954355A9439 /* UIView+Styles.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIView+Styles.h"; sourceTree = "<group>"; };
 		9FFD394F9233E022B335DFA5FFD3B1F3 /* Block.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Block.swift; sourceTree = "<group>"; };
 		A0B317E1EA110398F097C0B6C69A94E2 /* Styles.unit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Styles.unit.xcconfig; sourceTree = "<group>"; };
@@ -112,7 +112,7 @@
 		C851B44833CF91201FF09073AF795BB0 /* Styles-Unit-Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Styles-Unit-Tests-frameworks.sh"; sourceTree = "<group>"; };
 		C9E87D569DC8D811124881863946604D /* Pods-Styles_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Styles_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		CC72BF4141633592F575071409FA45F9 /* UIButton+Styles.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIButton+Styles.m"; sourceTree = "<group>"; };
-		CD8DB9DFC6E77F1C7DF3A64CFB76BC39 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		CD8DB9DFC6E77F1C7DF3A64CFB76BC39 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		CE49C1FC8A92F28C5762C054EA946175 /* TextDecoration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TextDecoration.swift; path = Styles/Classes/TextDecoration.swift; sourceTree = "<group>"; };
 		CE5E8AC880248FA233C3387DF943FB19 /* Shadow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Shadow.swift; path = Styles/Classes/Shadow.swift; sourceTree = "<group>"; };
 		D446777DC0C0BD0D40613E9FA3CD6E12 /* UITextField+Styles.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UITextField+Styles.h"; sourceTree = "<group>"; };

--- a/Example/Pods/Target Support Files/Styles/Info.plist
+++ b/Example/Pods/Target Support Files/Styles/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>0.17.13</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.18.13</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>${CURRENT_PROJECT_VERSION}</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
 </dict>
 </plist>

--- a/Example/Styles/Sources/Extensions/TextStyle+Defaults.swift
+++ b/Example/Styles/Sources/Extensions/TextStyle+Defaults.swift
@@ -22,7 +22,7 @@ extension TextStyle {
 		.letterSpacing(1.5),
 		.paragraphStyle([
 			.alignment(.natural),
-			.lineHeight(2.5)
+			.lineSpacing(2.5)
 			]),
 		.strikethrought(TextDecoration(
 			style: .thick,

--- a/Example/Styles/Sources/Extensions/TextStyle+Predefined.swift
+++ b/Example/Styles/Sources/Extensions/TextStyle+Predefined.swift
@@ -40,7 +40,7 @@ extension TextStyle {
 				.letterSpacing(1.5),
 				.paragraphStyle([
 					.alignment(.natural),
-					.lineHeight(2.5)
+					.lineSpacing(2.5)
 					]),
 				.strikethrought(TextDecoration(
 					style: .thick,
@@ -68,7 +68,7 @@ extension TextStyle {
 				.letterSpacing(1.5),
 				.paragraphStyle([
 					.alignment(.natural),
-					.lineHeight(2.5)
+					.lineSpacing(2.5)
 					]),
 				.strikethrought(TextDecoration(
 					style: .thick,

--- a/Example/Styles/Sources/Scenes/CustomStyle/DefineTextStyle/DefineTextStyle.storyboard
+++ b/Example/Styles/Sources/Scenes/CustomStyle/DefineTextStyle/DefineTextStyle.storyboard
@@ -193,8 +193,8 @@ Where is the remaining dollar?</string>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Line height (0)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="txL-qH-rdy">
-                                        <rect key="frame" x="16" y="116" width="112" height="21"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Line spacing (0)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="txL-qH-rdy">
+                                        <rect key="frame" x="16" y="116" width="123.5" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -361,8 +361,8 @@ Where is the remaining dollar?</string>
                         <outlet property="foregroundColorView" destination="bFV-Ca-maz" id="dhd-7b-Guf"/>
                         <outlet property="letterSpacingLabel" destination="YZS-NB-5j4" id="fpE-kZ-1OB"/>
                         <outlet property="letterSpacingSlider" destination="H3m-I4-m7S" id="4Th-2d-IL3"/>
-                        <outlet property="lineHeightLabel" destination="txL-qH-rdy" id="TER-kX-hCu"/>
-                        <outlet property="lineHeightSlider" destination="voh-V9-T2q" id="skm-FU-JvW"/>
+                        <outlet property="lineSpacingLabel" destination="txL-qH-rdy" id="TER-kX-hCu"/>
+                        <outlet property="lineSpacingSlider" destination="voh-V9-T2q" id="z49-H4-taX"/>
                         <outlet property="obliquenessLabel" destination="BaU-HZ-zMg" id="eTc-i6-qem"/>
                         <outlet property="obliquenessSlider" destination="UBi-sV-k4q" id="H3n-c1-Dhs"/>
                     </connections>

--- a/Example/Styles/Sources/Scenes/CustomStyle/DefineTextStyle/DefineTextStyleViewController.swift
+++ b/Example/Styles/Sources/Scenes/CustomStyle/DefineTextStyle/DefineTextStyleViewController.swift
@@ -9,8 +9,8 @@ final class DefineTextStyleViewController: UIViewController {
 	@IBOutlet weak var fontSizeSlider: UISlider!
 	@IBOutlet weak var backgroundColorView: UIView!
 	@IBOutlet weak var foregroundColorView: UIView!
-	@IBOutlet weak var lineHeightLabel: UILabel!
-	@IBOutlet weak var lineHeightSlider: UISlider!
+	@IBOutlet weak var lineSpacingLabel: UILabel!
+	@IBOutlet weak var lineSpacingSlider: UISlider!
 	@IBOutlet weak var alignmentControl: UISegmentedControl!
 	@IBOutlet weak var letterSpacingLabel: UILabel!
 	@IBOutlet weak var letterSpacingSlider: UISlider!
@@ -39,7 +39,7 @@ final class DefineTextStyleViewController: UIViewController {
 			.font(font),
 			.paragraphStyle([
 				.alignment(alignments[alignmentControl.selectedSegmentIndex]),
-				.lineHeight(CGFloat(lineHeightSlider.value))
+				.lineSpacing(CGFloat(lineSpacingSlider.value))
 				]),
 			.letterSpacing(CGFloat(letterSpacingSlider.value)),
 			.obliqueness(Double(obliquenessSlider.value)),
@@ -98,8 +98,8 @@ final class DefineTextStyleViewController: UIViewController {
 		switch sender.tag {
 		case fontSizeSlider.tag:
 			fontSizeLabel.text = "Font size \(value)"
-		case lineHeightSlider.tag:
-			lineHeightLabel.text = "Line height \(value)"
+		case lineSpacingSlider.tag:
+			lineSpacingLabel.text = "Line spacing \(value)"
 		case letterSpacingSlider.tag:
 			letterSpacingLabel.text = "Letter spacing \(value)"
 		case obliquenessSlider.tag:
@@ -149,7 +149,7 @@ final class DefineTextStyleViewController: UIViewController {
 			.font(\(font)),
 			.paragraphStyle([
 				.alignment(\(alignments[alignmentControl.selectedSegmentIndex].codeDescription)),
-				.lineHeight(\(CGFloat(lineHeightSlider.value)))
+				.lineSpacing(\(CGFloat(lineSpacingSlider.value)))
 			]),
 			.letterSpacing(\(CGFloat(letterSpacingSlider.value))),
 			.obliqueness(\(Double(obliquenessSlider.value))),

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ let h1 = TextStyle(
     .letterSpacing(1.5),
     .paragraphStyle([
         .alignment(.natural),
-        .lineHeight(2.5)
+        .lineSpacing(2.5)
     ]),
     .strikethrought(TextDecoration(
         style: .thick,
@@ -161,7 +161,7 @@ let h1 = TextStyle(
     .letterSpacing(1.5),
     .paragraphStyle([
         .alignment(.natural),
-        .lineHeight(2.5)
+        .lineSpacing(2.5)
     ]),
     .strikethrought(TextDecoration(
         style: .thick,

--- a/Styles.podspec
+++ b/Styles.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Styles'
-  s.version          = '0.17.13'
+  s.version          = '0.18.13'
   s.summary          = 'UI Elements rapid styling'
   s.description      = <<-DESC
 UIElements styling made easy, declarative and rapid.

--- a/Styles/Classes/TextStyle.swift
+++ b/Styles/Classes/TextStyle.swift
@@ -7,7 +7,7 @@ public extension NSMutableParagraphStyle {
         switch style {
         case let .alignment(textAlignment):
             alignment = textAlignment
-        case let .lineHeight(spacing):
+        case let .lineSpacing(spacing):
             lineSpacing = spacing
         }
     }
@@ -16,7 +16,7 @@ public extension NSMutableParagraphStyle {
 public final class TextStyle: NSObject {
     public enum ParagraphStyle {
         case alignment(NSTextAlignment)
-        case lineHeight(CGFloat)
+        case lineSpacing(CGFloat)
     }
 
     public enum WritingDirectionOverride: Int {

--- a/Styles/Tests/TextStyleTests.swift
+++ b/Styles/Tests/TextStyleTests.swift
@@ -33,7 +33,7 @@ final class TextStyleTests: XCTestCase {
     }
 
     func testParagraphStyle() {
-        let style = TextStyle(.paragraphStyle([.alignment(.center), .lineHeight(104)]))
+        let style = TextStyle(.paragraphStyle([.alignment(.center), .lineSpacing(104)]))
         let actual = style.attributes[.paragraphStyle] as? NSParagraphStyle
 
         XCTAssertNotNil(actual)


### PR DESCRIPTION
Renaming lineHeight because it was misleading since it behaves more like multiplier and not so much as CSS lineHeight. 

In other words: `lineHeight of 22pts != .lineSpacing(22)`