### PR TITLE
Fixing crashing UIActivityViewController on iOS 15

### DIFF
--- a/Styles/Classes/UIElement+Extensions/UILabel+Styles.m
+++ b/Styles/Classes/UIElement+Extensions/UILabel+Styles.m
@@ -29,10 +29,10 @@ SYNTHESIZE_PROPERTY_OBJ(TextStyle, textStyle, TextStyle);
 }
 
 - (void)updateText {
-    if (!self.attributedText.string || !self.textStyle) {
+    if (!self.attributedText.string || ![self.textStyle isKindOfClass: [TextStyle class]]) {
         return;
     }
-    self.attributedText = [self.textStyle applyTo:self.attributedText.string];
+    self.attributedText = [self.textStyle applyTo: self.attributedText.string];
 }
 
 @end


### PR DESCRIPTION
The UIActivityActionCellTitleLabel on iOS 15 contains "textStyle" property which isn't TextStyle. 